### PR TITLE
update go version to 1.23

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -6,7 +6,7 @@ name: app
 
 # The runtime the application uses.
 # Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
-type: golang:1.16
+type: golang:1.23
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed


### PR DESCRIPTION
## Description
Updates go run time from 1.16 to 1.23

## Motivation and Context
1.16 of Go is [deprecated](https://docs.platform.sh/languages/go.html#deprecated-versions) and no longer supported by Platform.sh/Upsun


